### PR TITLE
rewrite old style constructor to "__construct"

### DIFF
--- a/html/class/criteria.php
+++ b/html/class/criteria.php
@@ -96,7 +96,7 @@ class CriteriaElement
     /**
      * Constructor
      **/
-    public function CriteriaElement()
+    public function __construct()
     {
     }
 
@@ -330,7 +330,7 @@ class CriteriaCompo extends CriteriaElement
      * @param   object  $ele
      * @param   string  $condition
      **/
-    public function CriteriaCompo($ele=null, $condition='AND')
+    public function __construct($ele=null, $condition='AND')
     {
         if (isset($ele) && is_object($ele)) {
             $this->add($ele, $condition);
@@ -465,7 +465,7 @@ class Criteria extends CriteriaElement
      * @param   string  $value
      * @param   string  $operator
      **/
-    public function Criteria($column, $value='', $operator='=', $prefix = '', $function = '')
+    public function __construct($column, $value='', $operator='=', $prefix = '', $function = '')
     {
         $this->prefix = $prefix;
         $this->function = $function;

--- a/html/class/module.textsanitizer.php
+++ b/html/class/module.textsanitizer.php
@@ -76,7 +76,7 @@ class MyTextSanitizer
     *
     * @todo Sofar, this does nuttin' ;-)
     */
-    public function MyTextSanitizer()
+    public function __construct()
     {
         $this->mMakeClickablePostFilter =new XCube_Delegate();
         $this->mMakeClickablePostFilter->register('MyTextSanitizer.MakeClickablePostFilter');

--- a/html/class/token.php
+++ b/html/class/token.php
@@ -67,7 +67,7 @@ class XoopsToken
      * @param   $name   this token's name string.
      * @param   $timeout    effective time(if $timeout equal 0, this token will become unlimited)
      */
-    public function XoopsToken($name, $timeout = XOOPS_TOKEN_TIMEOUT)
+    public function __construct($name, $timeout = XOOPS_TOKEN_TIMEOUT)
     {
         $this->_name_ = $name;
 

--- a/html/class/xoopscomments.php
+++ b/html/class/xoopscomments.php
@@ -46,7 +46,7 @@ class xoopscomments extends XoopsObject
     {
         $this->ctable = $ctable;
         $this->db =& Database::getInstance();
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('comment_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('item_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('order', XOBJ_DTYPE_INT, null, false);

--- a/html/core/XCube_Utils.class.php
+++ b/html/core/XCube_Utils.class.php
@@ -18,7 +18,7 @@ class XCube_Utils
      * @private
      * @brief Private Constructor. In other words, it's impossible to generate an instance of this class.
      */
-    public function XCube_Utils()
+    public function __construct()
     {
     }
     

--- a/html/core/libs/IniHandler.class.php
+++ b/html/core/libs/IniHandler.class.php
@@ -21,7 +21,7 @@ class XCube_IniHandler
     /*** bool ***/    protected $_mSectionFlag = false;
 
     /**
-     * __constract
+     * __construct
      * 
      * @param	string	$filePath
      * @param	bool	$section

--- a/html/kernel/avatar.php
+++ b/html/kernel/avatar.php
@@ -39,7 +39,7 @@ class XoopsAvatar extends XoopsObject
 
     public function XoopsAvatar()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('avatar_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('avatar_file', XOBJ_DTYPE_OTHER, null, false, 30);
         $this->initVar('avatar_name', XOBJ_DTYPE_TXTBOX, null, true, 100);

--- a/html/kernel/comment.php
+++ b/html/kernel/comment.php
@@ -58,7 +58,7 @@ class XoopsComment extends XoopsObject
      **/
     public function __construct()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('com_id', XOBJ_DTYPE_INT, 0, false);
         $this->initVar('com_pid', XOBJ_DTYPE_INT, 0, false);
         $this->initVar('com_modid', XOBJ_DTYPE_INT, null, false);

--- a/html/kernel/config.php
+++ b/html/kernel/config.php
@@ -89,7 +89,7 @@ class XoopsConfigHandler
      * 
      * @param	object  &$db    reference to database object
      */
-    public function XoopsConfigHandler(&$db)
+    public function __construct(&$db)
     {
         $this->_cHandler =new XoopsConfigItemHandler($db);
         $this->_oHandler =new XoopsConfigOptionHandler($db);

--- a/html/kernel/configcategory.php
+++ b/html/kernel/configcategory.php
@@ -59,7 +59,7 @@ class XoopsConfigCategory extends XoopsObject
      */
     public function __construct()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('confcat_id', XOBJ_DTYPE_INT, null);
         $this->initVar('confcat_name', XOBJ_DTYPE_OTHER, null);
         $this->initVar('confcat_order', XOBJ_DTYPE_INT, 0);

--- a/html/kernel/configitem.php
+++ b/html/kernel/configitem.php
@@ -71,7 +71,7 @@ class XoopsConfigItem extends XoopsObject
     /**
      * Constructor
      */
-    public function XoopsConfigItem()
+    public function __construct()
     {
         static $initVars;
         if (isset($initVars)) {

--- a/html/kernel/configoption.php
+++ b/html/kernel/configoption.php
@@ -55,14 +55,14 @@ class XoopsConfigOption extends XoopsObject
     /**
      * Constructor
      */
-    public function XoopsConfigOption()
+    public function __construct()
     {
         static $initVars;
         if (isset($initVars)) {
             $this->vars = $initVars;
             return;
         }
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('confop_id', XOBJ_DTYPE_INT, null);
         $this->initVar('confop_name', XOBJ_DTYPE_TXTBOX, null, true, 255);
         $this->initVar('confop_value', XOBJ_DTYPE_TXTBOX, null, true, 255);

--- a/html/kernel/group.php
+++ b/html/kernel/group.php
@@ -52,7 +52,7 @@ class XoopsGroup extends XoopsObject
             $this->vars = $initVars;
             return;
         }
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('groupid', XOBJ_DTYPE_INT, null, false);
         $this->initVar('name', XOBJ_DTYPE_TXTBOX, null, true, 100);
         $this->initVar('description', XOBJ_DTYPE_TXTAREA, null, false);

--- a/html/kernel/groupperm.php
+++ b/html/kernel/groupperm.php
@@ -70,7 +70,7 @@ class XoopsGroupPerm extends XoopsObject
             $this->vars = $initVars;
             return;
         }
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('gperm_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('gperm_groupid', XOBJ_DTYPE_INT, null, false);
         $this->initVar('gperm_itemid', XOBJ_DTYPE_INT, null, false);

--- a/html/kernel/image.php
+++ b/html/kernel/image.php
@@ -47,7 +47,7 @@ class XoopsImage extends XoopsObject
      **/
     public function XoopsImage()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('image_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('image_name', XOBJ_DTYPE_OTHER, null, false, 30);
         $this->initVar('image_nicename', XOBJ_DTYPE_TXTBOX, null, true, 100);

--- a/html/kernel/imagecategory.php
+++ b/html/kernel/imagecategory.php
@@ -39,7 +39,7 @@ class XoopsImagecategory extends XoopsObject
 
     public function XoopsImagecategory()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('imgcat_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('imgcat_name', XOBJ_DTYPE_TXTBOX, null, true, 100);
         $this->initVar('imgcat_display', XOBJ_DTYPE_INT, 1, false);

--- a/html/kernel/imageset.php
+++ b/html/kernel/imageset.php
@@ -38,7 +38,7 @@ class XoopsImageset extends XoopsObject
 
     public function XoopsImageset()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('imgset_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('imgset_name', XOBJ_DTYPE_TXTBOX, null, true, 50);
         $this->initVar('imgset_refid', XOBJ_DTYPE_INT, 0, false);

--- a/html/kernel/imagesetimg.php
+++ b/html/kernel/imagesetimg.php
@@ -37,7 +37,7 @@ class XoopsImagesetimg extends XoopsObject
 {
     public function XoopsImagesetimg()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('imgsetimg_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('imgsetimg_file', XOBJ_DTYPE_OTHER, null, false);
         $this->initVar('imgsetimg_body', XOBJ_DTYPE_SOURCE, null, false);

--- a/html/kernel/module.php
+++ b/html/kernel/module.php
@@ -55,9 +55,9 @@ class XoopsModule extends XoopsObject
     /**
      * Constructor
      */
-    public function XoopsModule()
+    public function __construct()
     {
-        $this->XoopsObject();
+        parent::__construct();
         static $initVars;
         if (isset($initVars)) {
             $this->vars = $initVars;

--- a/html/kernel/notification.php
+++ b/html/kernel/notification.php
@@ -63,7 +63,7 @@ class XoopsNotification extends XoopsObject
      **/
     public function __construct()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('not_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('not_modid', XOBJ_DTYPE_INT, null, false);
         $this->initVar('not_category', XOBJ_DTYPE_TXTBOX, null, false, 30);

--- a/html/kernel/object.php
+++ b/html/kernel/object.php
@@ -173,7 +173,7 @@ class XoopsObject extends AbstractXoopsObject
     * normally, this is called from child classes only
     * @access public
     */
-    public function XoopsObject()
+    public function __construct()
     {
     }
 
@@ -705,7 +705,7 @@ class XoopsObjectHandler
      * @param object $db reference to the {@link XoopsDatabase} object
      * @access protected
      */
-    public function XoopsObjectHandler(&$db)
+    public function __construct(&$db)
     {
         $this->db =& $db;
     }

--- a/html/kernel/privmessage.php
+++ b/html/kernel/privmessage.php
@@ -49,7 +49,7 @@ class XoopsPrivmessage extends XoopsObject
  **/
     public function __construct()
     {
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('msg_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('msg_image', XOBJ_DTYPE_OTHER, 'icon1.gif', false, 100);
         $this->initVar('subject', XOBJ_DTYPE_TXTBOX, null, true, 255);

--- a/html/kernel/tplfile.php
+++ b/html/kernel/tplfile.php
@@ -41,7 +41,7 @@ class XoopsTplfile extends XoopsObject
             $this->vars = $initVars;
             return;
         }
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('tpl_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('tpl_refid', XOBJ_DTYPE_INT, 0, false);
         $this->initVar('tpl_tplset', XOBJ_DTYPE_OTHER, null, false);

--- a/html/kernel/tplset.php
+++ b/html/kernel/tplset.php
@@ -41,7 +41,7 @@ class XoopsTplset extends XoopsObject
             $this->vars = $initVars;
             return;
         }
-        $this->XoopsObject();
+        parent::__construct();
         $this->initVar('tplset_id', XOBJ_DTYPE_INT, null, false);
         $this->initVar('tplset_name', XOBJ_DTYPE_OTHER, null, false);
         $this->initVar('tplset_desc', XOBJ_DTYPE_TXTBOX, null, false, 255);

--- a/html/modules/legacy/class/comment.php
+++ b/html/modules/legacy/class/comment.php
@@ -103,7 +103,7 @@ class LegacyCommentHandler extends XoopsObjectGenericHandler
     public function __construct(&$db)
     // public function LegacyCommentHandler(&$db)
     {
-        parent::XoopsObjectGenericHandler($db);
+        parent::__construct($db);
         
         $this->mUpdateSuccess =new XCube_Delegate();
         $this->mDeleteSuccess =new XCube_Delegate();

--- a/html/modules/legacy/class/non_installation_module.php
+++ b/html/modules/legacy/class/non_installation_module.php
@@ -34,7 +34,7 @@ class LegacyNon_installation_moduleHandler extends XoopsObjectHandler
     public function __construct(&$db)
     // public function LegacyNon_installation_moduleHandler(&$db)
     {
-        parent::XoopsObjectHandler($db);
+        parent::__construct($db);
         $this->_setupObjects();
     }
 

--- a/html/modules/legacy/kernel/handler.php
+++ b/html/modules/legacy/kernel/handler.php
@@ -28,9 +28,9 @@ class XoopsObjectGenericHandler extends XoopsObjectHandler
      */
     public $_mDummyObj = null;
 
-    public function XoopsObjectGenericHandler(&$db)
+    public function __construct(&$db)
     {
-        parent::XoopsObjectHandler($db);
+        parent::__construct($db);
         $tableArr = explode('_', $this->mTable);
         $this->mDirname = array_shift($tableArr);
         $this->mDataname = implode('_', $tableArr);

--- a/html/modules/legacy/kernel/object.php
+++ b/html/modules/legacy/kernel/object.php
@@ -32,7 +32,7 @@ class XoopsSimpleObject extends AbstractXoopsObject
     public $mIsNew = true;
     public $mDirname = null;
     
-    public function XoopsSimpleObject()
+    public function __construct()
     {
     }
     

--- a/html/modules/message/class/handler/Inbox.class.php
+++ b/html/modules/message/class/handler/Inbox.class.php
@@ -48,7 +48,7 @@ class MessageInboxHandler extends XoopsObjectGenericHandler
   
     public function __construct(&$db)
     {
-        parent::XoopsObjectGenericHandler($db);
+        parent::__construct($db);
     }
   
     public function getCountUnreadByFromUid($uid)

--- a/html/modules/message/class/handler/Outbox.class.php
+++ b/html/modules/message/class/handler/Outbox.class.php
@@ -27,7 +27,7 @@ class MessageOutboxHandler extends XoopsObjectGenericHandler
   
     public function __construct(&$db)
     {
-        parent::XoopsObjectGenericHandler($db);
+        parent::__construct($db);
     }
   
     public function getOutboxCount($uid)

--- a/html/modules/message/class/handler/Settings.class.php
+++ b/html/modules/message/class/handler/Settings.class.php
@@ -29,7 +29,7 @@ class MessageSettingsHandler extends XoopsObjectGenericHandler
 
     public function __construct(&$db)
     {
-        parent::XoopsObjectGenericHandler($db);
+        parent::__construct($db);
     }
   
     public function chkUser($uid)


### PR DESCRIPTION
rewrite old style constructor method name to "__construct"

It reduce DEPRECATED warnings.
