### PR TITLE
MultiToken to be not inherited class.

### DIFF
--- a/html/class/token.php
+++ b/html/class/token.php
@@ -315,8 +315,13 @@ class XoopsSingleTokenHandler extends XoopsTokenHandler
  * This class publish a token of the different same name of a serial number
  * for the tab browser.
  */
-class XoopsMultiTokenHandler extends XoopsTokenHandler
+class XoopsMultiTokenHandler
 {
+    /**
+     * @access private
+     */
+    public $_prefix ="";
+
     public function &create($name, $timeout=XOOPS_TOKEN_TIMEOUT)
     {
         $token =new XoopsToken($name, $timeout);


### PR DESCRIPTION
XoopsMultiTokenHander class in class/token.php that inherit XoopsTokenHander class now.
But both are just method name is same,  method parameter is incompatible.

So both are different class, not inherit.

This is fixed follow warnings.
~~~
WARNING: Declaration of & XoopsMultiTokenHandler::fetch($name, $serial_number) should be compatible with & XoopsTokenHandler::fetch($name) in /home/mysite/xcl/html/class/token.php
WARNING: Declaration of XoopsMultiTokenHandler::isRegistered($name, $serial_number) should be compatible with XoopsTokenHandler::isRegistered($name) in /home/mysite/xcl/html/class/token.php
~~~