### PR TITLE
fix design compatibility for firefox

### DIFF
--- a/html/modules/legacy/admin/theme/stylesheets/ui-card.css
+++ b/html/modules/legacy/admin/theme/stylesheets/ui-card.css
@@ -290,6 +290,12 @@
 		width						: var(  --ui-card-block-item-width					);
 	}
 
+	/* input[size=] width depend using fonts, 
+	   then setting by style for compatibility */
+	.ui-card-block-item input[size="20"] {
+		width: 12em;
+	}
+
 	.ui-card-block-item.pad-left {
 		padding-left: 2em;
 	}


### PR DESCRIPTION
Admin dashboard block bit broken rendering in firefox. (overflow width in japanese)
This will be depend language/fonts, may be no problem Latin language.
Problem comes input[size=] width will depend using fonts.