### PR TITLE
create table charset force utf8

### DIFF
--- a/html/class/database/sqlutility.php
+++ b/html/class/database/sqlutility.php
@@ -152,6 +152,15 @@ class sqlutility
         if (preg_match($pattern, $query, $matches) || preg_match($pattern2, $query, $matches)) {
             $replace = "\\1 ".$prefix."_\\4\\5";
             $matches[0] = preg_replace($pattern, $replace, $query);
+
+            // CREATE TABLE force utf8
+            // DB Engine use default (remove MyISAM)
+            if ($matches[1] == "CREATE TABLE") {
+                $matches[0] = preg_replace("/ ENGINE=MyISAM/i", "", $matches[0]);
+                if (!preg_match("/ CHARACTER SET /i", $matches[0])) {
+                    $matches[0] .= " CHARACTER SET utf8";
+                }
+            }
             return $matches;
         }
         return false;


### PR DESCRIPTION
Create table character set forced utf8.
Resolve install time character set some problem.

And remove ENGINE=MyISAM setting. DB Engine use default setting.